### PR TITLE
Clarify usage and Python 3-only status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
     language: python
     python: '3.6'
     if: type != cron
+    env: DEPLOY="true"
   - os: osx
     language: generic
     osx_image: xcode9
@@ -32,11 +33,11 @@ deploy:
     password: ${PYPI_PASSWORD}
     on:
       tags: true
-      condition: "$TRAVIS_PYTHON_VERSION = '3.6'"
+      condition: "$DEPLOY = 'true'"
   - provider: pypi
     user: ${TEST_PYPI_USERNAME}
     server: https://test.pypi.org/legacy/
     password: ${TEST_PYPI_PASSWORD}
     on:
       branch: master
-      condition: "$TRAVIS_PYTHON_VERSION = '3.6'"
+      condition: "$DEPLOY = 'true'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@ matrix:
   - os: linux
     sudo: false
     language: python
-    python: '2.7'
-    if: type != cron
-  - os: linux
-    sudo: false
-    language: python
     python: '3.6'
     if: type != cron
   - os: osx
@@ -37,11 +32,11 @@ deploy:
     password: ${PYPI_PASSWORD}
     on:
       tags: true
-      condition: "$TRAVIS_PYTHON_VERSION = '2.7'"
+      condition: "$TRAVIS_PYTHON_VERSION = '3.6'"
   - provider: pypi
     user: ${TEST_PYPI_USERNAME}
     server: https://test.pypi.org/legacy/
     password: ${TEST_PYPI_PASSWORD}
     on:
       branch: master
-      condition: "$TRAVIS_PYTHON_VERSION = '2.7'"
+      condition: "$TRAVIS_PYTHON_VERSION = '3.6'"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 
 ![logo](logo.png)
 
+#### Requirements
+  * Python 3
+
 #### INSTALL
 To install by pip is just one step
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 #### Requirements
   * Python 3
+  * the Conan client
 
 #### INSTALL
 To install by pip is just one step
@@ -26,6 +27,10 @@ Or if you want to download our pip package
     pip install bincrafters_remove_outdated
 
 #### RUN
+Make sure your Conan client is logged in (`conan user`) the repository you want to clean. Then execute:
+
+    $ bincrafters-remove-outdated <repository>
+
 To remove **ALL** outdated packages on Bincrafters https://api.bintray.com/conan/bincrafters/public-conan
 
     $ bincrafters-remove-outdated bincrafters
@@ -55,9 +60,9 @@ To develop or run conan remove outdated
 There are two ways to upload this project.
 
 ##### Travis CI
-After to create a new tag, the package will be uploaded automatically to Pypi.  
+After to create a new tag, the package will be uploaded automatically to PyPi.  
 Both username and password (encrypted) are in travis file.  
-Only one job (python 2.7) will upload, the second one will be skipped.
+Only one job (Python 3.6) will upload, the others will be skipped.
 
 
 ##### Command line

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@ build: false
 
 
 environment:
-    PYTHON: "C:\\Python27"
-    PYTHON_VERSION: "2.7.8"
+    PYTHON: "C:\Python37"
+    PYTHON_VERSION: "3.7.0"
     PYTHON_ARCH: "32"
 
     matrix:

--- a/setup.py
+++ b/setup.py
@@ -74,9 +74,9 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7'
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
Imho Python 3-only support is absolutely fine since the clock is literally ticking for Python 2 https://pythonclock.org

If this is fine with you as well, then let's make the Python 3-only status clear and update the CI accordingly.