### PR TITLE
workaround travis killing jobs after 10 min silent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 - ".travis/install.sh"
 
 script:
-- ".travis/run.sh"
+- travis_wait 60 ".travis/run.sh"
 
 after_success:
 - codecov


### PR DESCRIPTION
https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
the drawback is that you do not get the output until the job is finished.